### PR TITLE
Emphasize that a "Global" Static IP Address is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Create a global IP address named `kubernetes-ingress`:
 gcloud compute addresses create kubernetes-ingress --global
 ```
 
+NOTE: When creating the Static Address through the console, please make sure
+to select the "Global" Type. A "Regional" Type is the default, but that will
+not work with the L7 Load Balancer used here.
+
 Create the `nginx` deployment:
 
 ```


### PR DESCRIPTION
This tripped me over: the console / GUI offers a Regional Static IP Address by default, but only a Global Static IP Address will work for this ... Hoping to help others avoid this gotcha :-)

Interestingly, it will also not "fail" hard, but just silently use an Ephemeral address instead ...